### PR TITLE
FIX: Update submission to CM issue

### DIFF
--- a/src/extensions/EditableCampaignMonitorField.php
+++ b/src/extensions/EditableCampaignMonitorField.php
@@ -209,7 +209,7 @@ class EditableCampaignMonitorField extends EditableFormField
     public function getValueFromData($data)
     {
         // if this field was set and there are lists - subscriper the user
-        if (isset($data[$this->Name]) && $this->getLists()->Count() > 0) {
+        if (array_key_exists($this->Name, $data) && $this->getLists()->Count() > 0) {
             $this->extend('beforeValueFromData', $data);
             $auth = array(null, 'api_key' => $this->config()->get('api_key'));
             $wrap = new \CS_REST_Subscribers($this->owner->getField('ListID'), $auth);
@@ -217,11 +217,16 @@ class EditableCampaignMonitorField extends EditableFormField
             $custom_fields = $this->getCustomFields($data);
             if (empty($custom_fields)) { $custom_fields = array(); }
 
+            $consent = 'no';
+
+            // @TODO - add consent to track funtionality
+
             $dataToSend = array(
                 'EmailAddress' => $data[$this->owner->getField('EmailField')],
                 'Name' => $data[$this->owner->getField('FirstNameField')].' '.$data[$this->owner->getField('LastNameField')],
                 'Resubscribe' => true,
-                'CustomFields' => $custom_fields
+                'CustomFields' => $custom_fields,
+                'ConsentToTrack' => $consent
             );
 
             $result = $wrap->add($dataToSend);


### PR DESCRIPTION
`ConsentToTrack` is now a required field, I have defaulted its value to "no" until a proper implementation can be added to allow users to choose this themselves. 

Additionally fixed the issue of no submitted value allowing this form to be ignored upon submission (it has no value and is a hidden field by default); as long as it is present in submission data it will now attempt a submission to CM.